### PR TITLE
Multi domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ servers:
 
 The project was only tested with a few specific setups, and certainly not with every possible combination of settings.
 
-In particular, expect automatic TLS to fail with anything more complicated than a single domain.
-
 ## Contributing
 
 Of course, pull requests are welcome. Keep in mind though that ease of use and as little configuration as possible are

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ a nice `nginx.conf` to nginx, and server your application via HTTPS with certifi
 Each entry in the `servers` section represents a separate virtual host.
 
 - `check_host_header`: optional, bool, default `yes`; whether to close connection on invalid `HTTP_HOST`
-- `server_name`: required, string; domain name where your site lives
+- `server_name`: required, string; domain name where your site lives, can be a list of domains separated with space
 - `static_files`: optional, string or mapping or array of mappings; maps a location on the virtual host to a mounted
  volume with static files
 

--- a/appconf.py
+++ b/appconf.py
@@ -229,10 +229,11 @@ def generate_tls_config(cert):
 
 
 def activate_lets_encrypt(server_name):
+    server_names = server_name.split(' ')
     with open('/tmp/le-domain.txt', 'w') as f:
-        f.write('-d ' + ' -d '.join(server_name.split(' ')))
-    if len(names := server_name.split(' ')) > 1:
-        server_name = names[0]
+        f.write(' '.join(f'-d {domain}' for domain in server_names))
+    if len(server_names) > 1:
+        server_name = server_names[0]
     return {
         'certificate': f'live/{server_name}/fullchain.pem',
         'key': f'live/{server_name}/privkey.pem',

--- a/appconf.py
+++ b/appconf.py
@@ -228,7 +228,9 @@ def generate_tls_config(cert):
 
 def activate_lets_encrypt(server_name):
     with open('/tmp/le-domain.txt', 'w') as f:
-        f.write(server_name)
+        f.write('-d ' + ' -d '.join(server_name.split(' ')))
+    if len(names := server_name.split(' ')) > 1:
+        server_name = names[0]
     return {
         'certificate': f'live/{server_name}/fullchain.pem',
         'key': f'live/{server_name}/privkey.pem',

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 python3 /opt/appconf.py /etc/appconf/nginx.yml > /etc/nginx/nginx.conf
 
 configure_letsencrypt() {
-  if [[ -z "${LETSENCRYPT_EMAIL}" ]] ; then
+  if [ -z "${LETSENCRYPT_EMAIL}" ] ; then
     echo "Please set LETSENCRYPT_EMAIL when using Let's Encrypt"
     exit 1
   fi
@@ -14,15 +14,15 @@ configure_letsencrypt() {
   fi
   if ! ls -1A /etc/letsencrypt/live/ | grep -q . ; then
     mkdir -p /var/www/letsencrypt
-    certbot certonly -n --standalone --webroot-path /var/www/letsencrypt --agree-tos --email ${LETSENCRYPT_EMAIL} -d $1
+    certbot certonly -n --standalone --webroot-path /var/www/letsencrypt --agree-tos --email "${LETSENCRYPT_EMAIL}" $1
   fi
   crontab /etc/cron.d/cert_renew
   crond
 }
 
 if [ -e /tmp/le-domain.txt ] ; then
-  DOMAIN=`cat /tmp/le-domain.txt`
-  configure_letsencrypt ${DOMAIN}
+  DOMAIN=$(cat /tmp/le-domain.txt)
+  configure_letsencrypt "${DOMAIN}"
 fi
 
 exec "$@"


### PR DESCRIPTION
### Main purpose
The purpose of these changes is to allow a user to set more than one domain in zombie-nginx configuration file.

### How it works
Zombie configuration should hold all domains with a space as a separator
Certbot will issue a certificate for all provided domains.
Http to https redirect now uses `http_host` instead of `server_name`, because when using `server_name` - nginx will redirect to the first value of `server_name`.

### Side updates
* Bumped `nginx` version
* Removed `gettext` and `envsubst` 
* Formatted `entrypoint.sh`.

### Docker Hub
https://hub.docker.com/layers/typeai/zombie-nginx/multi-domain/images/sha256-b4c8637697fcedec85a13ad320aff7e9ac16929dfab47cbc55630896ccbac74f?context=explore