### PR TITLE
Add upstream raw options

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Each entry in the `servers` section represents a separate virtual host.
 ### Setting nginx options directly
 
 To add or override an nginx option directly in the generated `nginx.conf` file, add desired settings in the
-`http_raw_options` or `server_raw_options` array.
+`http_raw_options`, `server_raw_options`, or `upstream_raw_options` array.
 
 ```yaml
 http_raw_options:
@@ -88,9 +88,14 @@ http_raw_options:
 servers:
   webapp:
     server_name: my-webapp.example.com
-    upstream: uwsgi://webapp:12345
     server_raw_options:
       - client_max_body_size 10M
+    upstream:
+      name: webapp-upstream
+      url:  uwsgi://webapp:12345
+      location: /
+      upstream_raw_options:
+        - add_header "Access-Control-Allow-Methods" "GET, POST, OPTIONS"
 ```
 
 ## Known issues

--- a/appconf.py
+++ b/appconf.py
@@ -194,8 +194,11 @@ def parse_single_upstream(server_name, config):
         'location': config['location'],
     }
 
-    if "upstream_raw_options" in config:
-        upstream.update(upstream_raw_options=config["upstream_raw_options"])
+    upstream_raw_options = config.get("upstream_raw_options", [])
+    if upstream_raw_options:
+        if not isinstance(upstream_raw_options, list):
+            raise Exception(f'{server_name}.upstream_raw_options must be an array')
+        upstream.update(upstream_raw_options=upstream_raw_options)
 
     for proto in 'http', 'uwsgi':
         if config['url'].startswith(f'{proto}://'):
@@ -297,6 +300,7 @@ def generate_server(name, description, upstreams):
             ('proxy_set_header', 'X-Forwarded-For', '$proxy_add_x_forwarded_for'),
             ('proxy_set_header', 'Host', '$http_host'),
         ]
+
         for option in upstream.get("upstream_raw_options", []):
             config.append(option.split(" "))
         if upstream['type'] == 'uwsgi':

--- a/appconf.py
+++ b/appconf.py
@@ -192,6 +192,10 @@ def parse_single_upstream(server_name, config):
         'name': config['name'],
         'location': config['location'],
     }
+
+    if "upstream_raw_options" in config:
+        upstream.update(upstream_raw_options=config["upstream_raw_options"])
+
     for proto in 'http', 'uwsgi':
         if config['url'].startswith(f'{proto}://'):
             upstream.update(url=config['url'][len(proto) + 3:], type=proto)
@@ -292,6 +296,8 @@ def generate_server(name, description, upstreams):
             ('proxy_set_header', 'X-Forwarded-For', '$proxy_add_x_forwarded_for'),
             ('proxy_set_header', 'Host', '$http_host'),
         ]
+        for option in upstream.get("upstream_raw_options", []):
+            config.append(option.split(" "))
         if upstream['type'] == 'uwsgi':
             config.append(('include', 'uwsgi_params'))
             config.append(('uwsgi_pass', upstream['name']))

--- a/appconf.py
+++ b/appconf.py
@@ -134,6 +134,7 @@ def emit_nginx_conf(config, *, indent=0):
     white = ' ' * indent
     for item in config:
         if isinstance(item[-1], list):
+            print(white)
             print(white + ' '.join(item[0:-1]) + ' {')
             emit_nginx_conf(item[-1], indent=indent + 2)
             print(white + '}')


### PR DESCRIPTION
1. Add `upstream_raw_options`.
2. Improve readability of generated config by adding empty line before each nested element.